### PR TITLE
Overwrite existing config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ init:
 		php artisan key:generate;\
 	fi
 
-	php artisan vendor:publish --tag=lfm_public
-	php artisan vendor:publish --tag=lfm_config
+	php artisan vendor:publish --tag=lfm_public --force
+	php artisan vendor:publish --tag=lfm_config --force
 	touch database/database.sqlite
 	php artisan migrate:refresh --seed
 


### PR DESCRIPTION
The current config is not valid with param `lfm.url_prefix` instead of `lfm.prefix`